### PR TITLE
added eye icon to toggle password visibility

### DIFF
--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -6,12 +6,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Checkbox } from "@/components/ui/checkbox"
-import { Github, Mail, Terminal } from "lucide-react"
+import { Github, Mail, Terminal, Eye, EyeOff } from "lucide-react"
 import { Link } from "react-router-dom"
 
 export default function LoginPage() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false) // Toggle state
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-gray-900 to-slate-900 flex items-center justify-center p-4">
@@ -73,18 +74,25 @@ export default function LoginPage() {
                 required
               />
             </div>
-            <div className="space-y-2">
+            <div className="relative space-y-2">
               <Label htmlFor="password" className="text-white font-medium">
                 Password
               </Label>
               <Input
                 id="password"
-                type="password"
+                type={showPassword ? "text" : "password"} // toggle type
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="bg-gray-800/50 border-gray-700 text-white placeholder:text-gray-400 focus:border-emerald-500"
+                className="bg-gray-800/50 border-gray-700 text-white placeholder:text-gray-400 focus:border-emerald-500 pr-10"
                 required
               />
+              {/* Eye Icon */}
+              <div
+                className="absolute right-3 top-[60%] -translate-y-1/2 cursor-pointer text-gray-400 hover:text-gray-200"
+                onClick={() => setShowPassword(!showPassword)}
+              >
+                {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+              </div>
             </div>
             <div className="flex items-center space-x-2">
               <Checkbox id="remember" className="border-gray-600" />

--- a/src/components/SignupPage.tsx
+++ b/src/components/SignupPage.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Github, Mail, Terminal } from "lucide-react"
+import { Github, Mail, Terminal, Eye, EyeOff } from "lucide-react"
 import { Link } from "react-router-dom"
 
 export default function SignupPage() {
@@ -19,6 +19,9 @@ export default function SignupPage() {
     confirmPassword: "",
     userType: "",
   })
+
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
 
   const updateFormData = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
@@ -132,32 +135,46 @@ export default function SignupPage() {
               </Select>
             </div>
 
-            <div className="space-y-2">
+            {/* Password Field */}
+            <div className="relative space-y-2">
               <Label htmlFor="password" className="text-white font-medium">
                 Password
               </Label>
               <Input
                 id="password"
-                type="password"
+                type={showPassword ? "text" : "password"}
                 value={formData.password}
                 onChange={(e) => updateFormData("password", e.target.value)}
-                className="bg-gray-800/50 border-gray-700 text-white placeholder:text-gray-400 focus:border-emerald-500"
+                className="bg-gray-800/50 border-gray-700 text-white placeholder:text-gray-400 focus:border-emerald-500 pr-10"
                 required
               />
+              <div
+                className="absolute right-3 top-[60%] -translate-y-1/2 cursor-pointer text-gray-400 hover:text-gray-200"
+                onClick={() => setShowPassword(!showPassword)}
+              >
+                {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+              </div>
             </div>
 
-            <div className="space-y-2">
+            {/* Confirm Password Field */}
+            <div className="relative space-y-2">
               <Label htmlFor="confirmPassword" className="text-white font-medium">
                 Confirm Password
               </Label>
               <Input
                 id="confirmPassword"
-                type="password"
+                type={showConfirmPassword ? "text" : "password"}
                 value={formData.confirmPassword}
                 onChange={(e) => updateFormData("confirmPassword", e.target.value)}
-                className="bg-gray-800/50 border-gray-700 text-white placeholder:text-gray-400 focus:border-emerald-500"
+                className="bg-gray-800/50 border-gray-700 text-white placeholder:text-gray-400 focus:border-emerald-500 pr-10"
                 required
               />
+              <div
+                className="absolute right-3 top-[60%] -translate-y-1/2 cursor-pointer text-gray-400 hover:text-gray-200"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+              >
+                {showConfirmPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+              </div>
             </div>
 
             <div className="flex items-center space-x-2">


### PR DESCRIPTION
# 🛠 Pull Request Template


## 📌 Related Issue


Fixes: #21 


---




## 🔍 Describe your changes?
This PR enhances the SignupPage UI by adding the ability for users to toggle the visibility of their password and confirm password fields. Key changes include:

- Introduced showPassword and showConfirmPassword state variables to manage visibility.
- Added eye icons (Eye / EyeOff) inside the password input fields for toggling.
- Updated input types dynamically based on the toggle state (password ↔ text).
- Ensured icons are clickable and styled to match the dark-themed signup form.
- Maintained responsive design and UI consistency with existing form components



---


## 📸 Screenshot

<img width="590" height="220" alt="image" src="https://github.com/user-attachments/assets/4a5c1758-3530-434b-8dca-5078a980b6f8" />

<!-- Insert a screenshot showing the new or fixed behavior -->
<!--(link-to-screenshot) -->


---


## 🧪 Checklist


Please check all that apply:


- [X] I have tested my changes locally.
- [X] I have followed the project's code style and guidelines.
- [X] I have added necessary comments and documentation.
- [X] The code compiles and runs without errors.




---


## 🗒️ Additional Notes (Optional)




---


## Thank you for contributing!


---
